### PR TITLE
240929 - Map Reset config, distance-oriented marking #1

### DIFF
--- a/include/SlamUtil.h
+++ b/include/SlamUtil.h
@@ -36,6 +36,9 @@ protected:
     ros::Publisher hector_msg_pub;
     ros::Publisher marker_pub; // waypoint 가시화 하기 위함
 
+    geometry_msgs::Pose pose_data, previous_pose_data, origin_pose;
+
+
 
     
     slamUtil::Trajectory trajectory;


### PR DESCRIPTION
Lap 1 일때, 처음 지점에서 맵이 초기화되는 현상 발생

초기 지점 설정에서, 제대로 먹히지 않았던 것으로 확인

origin_pose (geometry_msgs::Pose) 관련해서 코드를 수정해야 함
![image](https://github.com/user-attachments/assets/b0aaf991-c148-40dd-bb45-bcda6de870ed)
